### PR TITLE
Implement buffer operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,46 @@ Stream finished.
 ## Operators
 
 <!-- OPERATORS_BEGIN -->
+### buffer
+
+**Signature:**
+```ts
+export function buffer<T>(predicate: (chunk: T) => boolean): (readableStream: ReadableStream<T>) => ReadableStream<T[]>;
+```
+
+**Description:**
+Buffers chunks in the readable stream based on a predicate function.
+
+<details><summary>Example</summary>
+
+```ts
+const stream = from([1, 2, 3, 4, 5]);
+const resultStream = pipe(stream, buffer(x => x % 2 === 0));
+await toPromise(resultStream); // Output: [[1, 2], [3, 4], [5]]
+```
+
+</details>
+
+### bufferCount
+
+**Signature:**
+```ts
+export function bufferCount<T>(count: number): (readableStream: ReadableStream<T>) => ReadableStream<T[]>;
+```
+
+**Description:**
+Buffers a specified number of items in the readable stream.
+
+<details><summary>Example</summary>
+
+```ts
+const stream = from([1, 2, 3, 4, 5]);
+const resultStream = pipe(stream, bufferCount(2));
+await toPromise(resultStream); // Output: [[1, 2], [3, 4], [5]]
+```
+
+</details>
+
 ### filter
 
 **Signature:**

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,3 +15,5 @@ export * from './operators/takeUntil';
 export * from './operators/zip';
 export * from './operators/pairwise';
 export * from './conversions/from';
+export * from './operators/buffer';
+export * from './operators/bufferCount';

--- a/src/operators/buffer.ts
+++ b/src/operators/buffer.ts
@@ -1,0 +1,57 @@
+import { curry } from '../utils/curry';
+import { from } from '../conversions/from';
+import { toPromise } from '../conversions/toPromise';
+
+/**
+ * Buffers chunks in the readable stream based on a predicate function.
+ * @param predicate - The predicate function to open/close the buffer.
+ * @returns A function that takes a readable stream and returns a new readable stream with the buffered chunks.
+ * 
+ * @example
+ * const stream = from([1, 2, 3, 4, 5]);
+ * const resultStream = pipe(stream, buffer(x => x % 2 === 0));
+ * await toPromise(resultStream); // Output: [[1, 2], [3, 4], [5]]
+ */
+export function buffer<T>(predicate: (chunk: T) => boolean): (readableStream: ReadableStream<T>) => ReadableStream<T[]> {
+  return curry(bufferStream)(predicate);
+}
+
+/**
+ * Buffers chunks in the readable stream based on a predicate function.
+ * @param predicate - The predicate function to open/close the buffer.
+ * @param readableStream - The readable stream to buffer.
+ * @returns A new readable stream with the buffered chunks.
+ */
+export function bufferStream<T>(predicate: (chunk: T) => boolean, readableStream: ReadableStream<T>): ReadableStream<T[]> {
+  let buffer: T[] = [];
+  const transformStream = new TransformStream({
+    transform(chunk, controller) {
+      buffer.push(chunk);
+      if (predicate(chunk)) {
+        controller.enqueue(buffer);
+        buffer = [];
+      }
+    },
+    flush(controller) {
+      if (buffer.length > 0) {
+        controller.enqueue(buffer);
+      }
+    }
+  });
+
+  return readableStream.pipeThrough(transformStream);
+}
+
+// Tests for buffer function using vitest
+if (import.meta.vitest) {
+  const { describe, it, expect } = import.meta.vitest;
+  const { pipe } = await import('../utils/pipe');
+
+  describe('buffer', () => {
+    it('should buffer chunks based on the provided predicate function', async () => {
+      const stream = from([1, 2, 3, 4, 5]);
+      const resultStream = pipe(stream, buffer(x => x % 2 === 0));
+      expect(await toPromise(resultStream)).toEqual([[1, 2], [3, 4], [5]]);
+    });
+  });
+}

--- a/src/operators/bufferCount.ts
+++ b/src/operators/bufferCount.ts
@@ -1,0 +1,37 @@
+import { buffer } from './buffer';
+
+/**
+ * Buffers a specified number of items in the readable stream.
+ * @param count - The number of items to buffer.
+ * @returns A function that takes a readable stream and returns a new readable stream with the buffered items.
+ * 
+ * @example
+ * const stream = from([1, 2, 3, 4, 5]);
+ * const resultStream = pipe(stream, bufferCount(2));
+ * await toPromise(resultStream); // Output: [[1, 2], [3, 4], [5]]
+ */
+export function bufferCount<T>(count: number): (readableStream: ReadableStream<T>) => ReadableStream<T[]> {
+  return (readableStream: ReadableStream<T>) => {
+    let itemCount = 0;
+    return buffer(() => {
+      itemCount++;
+      return itemCount % count === 0;
+    })(readableStream);
+  };
+}
+
+// Tests for bufferCount function using vitest
+if (import.meta.vitest) {
+  const { describe, it, expect } = import.meta.vitest;
+  const { from } = await import('../conversions/from');
+  const { toPromise } = await import('../conversions/toPromise');
+  const { pipe } = await import('../utils/pipe');
+
+  describe('bufferCount', () => {
+    it('should buffer the specified number of items', async () => {
+      const stream = from([1, 2, 3, 4, 5]);
+      const resultStream = pipe(stream, bufferCount(2));
+      expect(await toPromise(resultStream)).toEqual([[1, 2], [3, 4], [5]]);
+    });
+  });
+}


### PR DESCRIPTION
Implement buffer and bufferCount operators for ReadableStream.

* **buffer.ts**
  - Add `buffer` function to open/close buffer based on predicate.
  - Add @example for `buffer` function.
  - Ensure `buffer` function does not drop any items.
  - Add tests for `buffer` function using vitest.

* **bufferCount.ts**
  - Add `bufferCount` function to buffer a specified number of items.
  - Use `buffer` function in `bufferCount` implementation.
  - Add @example for `bufferCount` function.
  - Add tests for `bufferCount` function using vitest.

* **index.ts**
  - Import and export `buffer` function from `src/operators/buffer.ts`.
  - Import and export `bufferCount` function from `src/operators/bufferCount.ts`.

* **README.md**
  - Add documentation for `buffer` and `bufferCount` operators with examples.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Yshayy/hi-stream/pull/9?shareId=a14b6c41-c930-4e09-84c2-d8febb8c7409).